### PR TITLE
feat(dbsync): Log database sync run in DB

### DIFF
--- a/bin/start.js
+++ b/bin/start.js
@@ -17,48 +17,55 @@ const DEFAULT_LXD_CONFIG_PATH = './lxdhub.yml';
 const ROOT = path.join(__dirname, '..');
 
 const database = {
-    host: process.env.POSTGRES_HOST || 'localhost',
-    port: parseInt(process.env.POSTGRES_PORT, 10) || 5432,
-    username: process.env.POSTGRES_USER || 'lxdhub',
-    password: process.env.POSTGRES_PASSWORD || 'lxdhub',
-    database: process.env.POSTGRES_DATABASE || 'lxdhub',
+  host: process.env.POSTGRES_HOST || 'localhost',
+  port: parseInt(process.env.POSTGRES_PORT, 10) || 5432,
+  username: process.env.POSTGRES_USER || 'lxdhub',
+  password: process.env.POSTGRES_PASSWORD || 'lxdhub',
+  database: process.env.POSTGRES_DATABASE || 'lxdhub'
 };
 
 const lxdConfigPath = process.env.LXDHUB_CONFIG || DEFAULT_LXD_CONFIG_PATH;
-const lxdConifgAbsolutePath =
-    path.isAbsolute(lxdConfigPath) ?
-        lxdConfigPath :
-        path.join(ROOT, lxdConfigPath);
-
+const lxdConifgAbsolutePath = path.isAbsolute(lxdConfigPath)
+  ? lxdConfigPath
+  : path.join(ROOT, lxdConfigPath);
 
 // Sync Interval in minutes
-const syncInterval = (parseInt(process.env.SYNC_INTERVAL) || DEFAULT_SYNC_INTERVAL) * 1000 * 60;
+const syncInterval =
+  (parseInt(process.env.SYNC_INTERVAL) || DEFAULT_SYNC_INTERVAL) * 1000 * 60;
 const logLevel = process.env.LOG_LEVEL || 'silly';
+const force =
+  (process.env.FORCE === 'true' || process.env.FORCE === '1') || false;
 
 const startDbsync = async () => {
-    // Function, which will be run as interval
-    const intervalTask = () =>
-        // Read the config file
-        fs.readFile(lxdConifgAbsolutePath, 'utf8')
-            // Convert from YAML to JSON
-            .then(content => YAML.safeLoad(content))
-            // Create the database sync instance
-            .then(lxdhubConfig => new LXDHubDbSync({ lxd, database, logLevel, lxdhubConfig }))
-            // Run the database sync script
-            .then(dbSync => dbSync.run())
-            .catch(err => console.error(err));
+  // Function, which will be run as interval
+  const intervalTask = () =>
+    // Read the config file
+    fs
+      .readFile(lxdConifgAbsolutePath, 'utf8')
+      // Convert from YAML to JSON
+      .then(content => YAML.safeLoad(content))
+      // Create the database sync instance
+      .then(
+        lxdhubConfig =>
+          new LXDHubDbSync({ lxd, database, logLevel, lxdhubConfig, force })
+      )
+      // Run the database sync script
+      .then(dbSync => dbSync.run())
+      .catch(err => console.error(err));
 
-    // Run task when starting
-    intervalTask();
+  // Run task when starting
+  intervalTask();
 
-    // Register interval
-    setInterval(() => intervalTask(), syncInterval);
-}
-
+  // Register interval
+  setInterval(() => intervalTask(), syncInterval);
+};
 
 if (servicesToStart.indexOf('dbsync') !== -1) {
-    startDbsync();
+  startDbsync();
 }
-if (servicesToStart.indexOf('api') !== -1 && servicesToStart.indexOf('ui') !== -1) {
-    startApiUi();
+if (
+  servicesToStart.indexOf('api') !== -1 &&
+  servicesToStart.indexOf('ui') !== -1
+) {
+  startApiUi();
 }

--- a/packages/db/src/database/database.service.ts
+++ b/packages/db/src/database/database.service.ts
@@ -22,9 +22,9 @@ export class DatabaseService {
      * connected
      */
     async closeConnection() {
-        const connection = (await this.connection);
+        const connection = this.connection;
         if (connection.isConnected) {
-            await (await this.connection).close();
+            await this.connection.close();
         }
     }
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -8,3 +8,4 @@
  */
 export * from './models';
 export * from './database';
+export { SyncState } from './models/sync-run.entity';

--- a/packages/db/src/models/index.ts
+++ b/packages/db/src/models/index.ts
@@ -5,3 +5,4 @@ export * from './architecture.entity';
 export * from './alias.entity';
 export * from './remote.entity';
 export * from './operating-sytem-architecture.entity';
+export { SyncRun } from './sync-run.entity';

--- a/packages/db/src/models/sync-run.entity.ts
+++ b/packages/db/src/models/sync-run.entity.ts
@@ -1,0 +1,32 @@
+import { Entity, PrimaryGeneratedColumn, Column, BaseEntity } from 'typeorm';
+
+export enum SyncState {
+  NOT_STARTED = 0,
+  RUNNING = 1,
+  FAILED = 2,
+  SUCCEEDED = 3,
+}
+
+/**
+ * Represents a run by the database synchronization tool
+ */
+@Entity()
+export class SyncRun extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', default: Date.now() })
+  created: Date;
+
+  @Column({ type: 'varchar', nullable: true })
+  started?: Date;
+
+  @Column({ type: 'varchar', nullable: true })
+  ended?: Date;
+
+  @Column({ type: 'enum', enum: SyncState, default: SyncState.NOT_STARTED  })
+  state: SyncState;
+
+  @Column({ type: 'varchar', nullable: true })
+  error?: string;
+}

--- a/packages/dbsync/bin/start-dbsync.js
+++ b/packages/dbsync/bin/start-dbsync.js
@@ -5,7 +5,7 @@ const path = require('path');
 const YAML = require('js-yaml');
 
 // Default time (in minutes) when the interval task should be executed
-const DEFAULT_SYNC_INTERVAL = 3;
+const DEFAULT_SYNC_INTERVAL = 5;
 
 const DEFAULT_LXD_CONFIG_PATH = './lxdhub.yml';
 
@@ -15,39 +15,41 @@ const certPath = process.env.LXD_CERT || 'certificates/client.crt';
 const keyPath = process.env.LXD_KEY || 'certificates/client.key';
 
 const lxd = {
-    cert: fs.readFileSync(path.join(ROOT, certPath)),
-    key: fs.readFileSync(path.join(ROOT, keyPath))
+  cert: fs.readFileSync(path.join(ROOT, certPath)),
+  key: fs.readFileSync(path.join(ROOT, keyPath))
 };
 
 const database = {
-    host: process.env.POSTGRES_HOST || 'localhost',
-    port: parseInt(process.env.POSTGRES_PORT, 10) || 5432,
-    username: process.env.POSTGRES_USER || 'lxdhub',
-    password: process.env.POSTGRES_PASSWORD || 'lxdhub',
-    database: process.env.POSTGRES_DATABASE || 'lxdhub',
+  host: process.env.POSTGRES_HOST || 'localhost',
+  port: parseInt(process.env.POSTGRES_PORT, 10) || 5432,
+  username: process.env.POSTGRES_USER || 'lxdhub',
+  password: process.env.POSTGRES_PASSWORD || 'lxdhub',
+  database: process.env.POSTGRES_DATABASE || 'lxdhub'
 };
 
 const lxdConfigPath = process.env.LXDHUB_CONFIG || DEFAULT_LXD_CONFIG_PATH;
-const lxdConifgAbsolutePath =
-    path.isAbsolute(lxdConfigPath) ?
-        lxdConfigPath :
-        path.join(ROOT, lxdConfigPath);
+const lxdConifgAbsolutePath = path.isAbsolute(lxdConfigPath)
+  ? lxdConfigPath
+  : path.join(ROOT, lxdConfigPath);
 
+const force =
+  process.env.FORCE === 'true' || process.env.FORCE === '1' || false;
 
 // Sync Interval in minutes
-const syncInterval = (parseInt(process.env.SYNC_INTERVAL) || DEFAULT_SYNC_INTERVAL) * 1000 * 60;
+const syncInterval =
+  (parseInt(process.env.SYNC_INTERVAL) || DEFAULT_SYNC_INTERVAL) * 1000 * 60;
 
 // Function, which will be run as interval
 const intervalTask = () =>
-    // Read the config file
-    fs.readFile(lxdConifgAbsolutePath, 'utf8')
-        // Convert from YAML to JSON
-        .then(content => YAML.safeLoad(content))
-        // Create the database sync instance
-        .then(lxdhubConfig => new LXDHubDbSync({ lxd, database, lxdhubConfig }))
-        // Run the database sync script
-        .then(dbSync => dbSync.run());
-
+  // Read the config file
+  fs
+    .readFile(lxdConifgAbsolutePath, 'utf8')
+    // Convert from YAML to JSON
+    .then(content => YAML.safeLoad(content))
+    // Create the database sync instance
+    .then(lxdhubConfig => new LXDHubDbSync({ lxd, database, lxdhubConfig, force }))
+    // Run the database sync script
+    .then(dbSync => dbSync.run());
 
 // Run task when starting
 intervalTask();

--- a/packages/dbsync/src/app.module.ts
+++ b/packages/dbsync/src/app.module.ts
@@ -11,34 +11,35 @@ import { ImageModule } from './image';
 import { AliasModule } from './alias/alias.module';
 import { OperatingArchitectureModule } from './os-arch';
 import { ImageAvailabilityModule } from './image-availability';
+import { SyncRunModule } from './sync-run';
 import { AppService } from './app.service';
+import { SETTINGS } from './app.tokens';
 
 /**
  * The main appliaction module for LXDHub database sync
  */
 export class AppModule {
-    /**
-     * Returns the app module with the applied settings
-     * @param settings The settings of the synchronization task
-     */
-    public static forRoot(settings: LXDHubDbSyncSettings): DynamicModule {
-        return {
-            module: AppModule,
-            providers: [
-                AppService
-            ],
-            imports: [
-                DatabaseModule.forRoot({ ...settings.database }),
-                AppSettingsModule.forRoot(settings),
-                LXDModule,
-                RemoteModule,
-                OperatingSystemModule,
-                ArchitectureModule,
-                AliasModule,
-                ImageModule,
-                ImageAvailabilityModule,
-                OperatingArchitectureModule,
-            ],
-        };
-    }
+  /**
+   * Returns the app module with the applied settings
+   * @param settings The settings of the synchronization task
+   */
+  public static forRoot(settings: LXDHubDbSyncSettings): DynamicModule {
+    return {
+      module: AppModule,
+      providers: [AppService, { provide: SETTINGS, useValue: settings }],
+      imports: [
+        DatabaseModule.forRoot({ ...settings.database }),
+        AppSettingsModule.forRoot(settings),
+        LXDModule,
+        RemoteModule,
+        OperatingSystemModule,
+        ArchitectureModule,
+        AliasModule,
+        ImageModule,
+        ImageAvailabilityModule,
+        OperatingArchitectureModule,
+        SyncRunModule
+      ]
+    };
+  }
 }

--- a/packages/dbsync/src/app.service.ts
+++ b/packages/dbsync/src/app.service.ts
@@ -1,5 +1,10 @@
-import { DatabaseService } from '@lxdhub/db';
-import { Injectable, Logger } from '@nestjs/common';
+import { DatabaseService, SyncRun } from '@lxdhub/db';
+import {
+  Injectable,
+  Logger,
+  Inject,
+  OnApplicationShutdown
+} from '@nestjs/common';
 
 import { AliasService } from './alias';
 import { ArchitectureService } from './architecture';
@@ -8,48 +13,109 @@ import { ImageAvailabilityService } from './image-availability';
 import { OperatingSystemService } from './operating-system';
 import { OsArchService } from './os-arch';
 import { RemoteService } from './remote';
+import { SyncRunService } from './sync-run';
+import { LXDHubDbSyncSettings } from './dbsync-settings.interface';
+import { SETTINGS } from './app.tokens';
 
 @Injectable()
 /**
  * The app services orchastrates the database synchronizer
  */
-export class AppService {
-    private logger: Logger;
+export class AppService implements OnApplicationShutdown {
+  private logger: Logger;
+  private syncRun?: SyncRun;
 
-    /**
-     * Initializes the app service
-     */
-    constructor(
-        private remoteService: RemoteService,
-        private operatingSystemService: OperatingSystemService,
-        private architectureService: ArchitectureService,
-        private imageService: ImageService,
-        private aliasService: AliasService,
-        private osArchService: OsArchService,
-        private imageAvailabilityService: ImageAvailabilityService,
-        private databaseService: DatabaseService
-    ) {
-        this.logger = new Logger('Database Synchronizer');
+  /**
+   * Initializes the app service
+   */
+  constructor(
+    private readonly remoteService: RemoteService,
+    private readonly operatingSystemService: OperatingSystemService,
+    private readonly architectureService: ArchitectureService,
+    private readonly imageService: ImageService,
+    private readonly aliasService: AliasService,
+    private readonly osArchService: OsArchService,
+    private readonly imageAvailabilityService: ImageAvailabilityService,
+    private readonly databaseService: DatabaseService,
+    private readonly syncRunService: SyncRunService,
+    @Inject(SETTINGS) private readonly settings: LXDHubDbSyncSettings
+  ) {
+    this.logger = new Logger('Database Synchronizer');
+  }
+
+  private async run() {
+    if (this.settings.force) {
+      this.syncRunService.resetAllSyncStates();
+    } else {
+      const currentlyRunningSyncs = await this.syncRunService.getCurrentlyRunningSyncs();
+
+      if (currentlyRunningSyncs.length > 1) {
+        const logMessage =
+          `There are currently ${
+            currentlyRunningSyncs.length
+          } other synchronization tasks running.\n` +
+          currentlyRunningSyncs
+            .map(sync => `- Sync #${sync.id} started at ${sync.started}`)
+            .join('\n') +
+          `You can enforce this database synchronization run by adding the "FORCE=true" environment variable.`;
+        this.logger.error(logMessage);
+        throw new Error(logMessage);
+      }
     }
 
-    /**
-     * Start the database synchronizer.
-     */
-    async synchronize() {
-        this.logger.log('==> Starting database synchronization');
+    await this.syncRunService.startSyncRun(this.syncRun.id);
 
-        // Run the synchronizers
-        await this.remoteService.synchronize();
-        await this.imageService.synchronize();
-        await this.operatingSystemService.synchronize();
-        await this.architectureService.synchronize();
-        await this.aliasService.synchronize();
-        await this.osArchService.synchronize();
-        await this.imageAvailabilityService.synchronize();
+    this.logger.log(`==> Started synchronization #${this.syncRun.id}`);
 
-        // Closes the database connection
-        await this.databaseService.closeConnection();
-        this.logger.log('==> Finished database synchronization');
+    // Run the synchronizers
+    await this.remoteService.synchronize();
+    await this.imageService.synchronize();
+    await this.operatingSystemService.synchronize();
+    await this.architectureService.synchronize();
+    await this.aliasService.synchronize();
+    await this.osArchService.synchronize();
+    await this.imageAvailabilityService.synchronize();
+  }
+
+  /**
+   * Start the database synchronizer.
+   */
+  async synchronize() {
+    this.syncRun = await this.syncRunService.createSyncRun();
+    this.logger.log(
+      `==> Starting database synchronization #${this.syncRun.id}`
+    );
+
+    try {
+      await this.run();
+      await this.syncRunService.finishSyncRun(this.syncRun.id);
+    } catch (ex) {
+      await this.syncRunService.failSyncRun(
+        this.syncRun.id,
+        ex ? (ex as Error).message : ''
+      );
     }
 
+    // Closes the database connection
+    this.logger.log(
+      `==> Finished database synchronization #${this.syncRun.id}`
+    );
+  }
+
+  async onApplicationShutdown(signal?: string) {
+    this.logger.error(`Database sync shutting down ${signal}`);
+    try {
+      await this.databaseService.connection.connect();
+      await this.syncRunService.failSyncRun(
+        this.syncRun.id,
+        `Database synchronization shutdown ${signal}`
+      );
+      await this.databaseService.closeConnection();
+    } catch (ex) {
+      this.logger.error(
+        `Failed gracefully shutting down dbsync: ${ex.message}`
+      );
+    }
+    process.exit(1);
+  }
 }

--- a/packages/dbsync/src/app.tokens.ts
+++ b/packages/dbsync/src/app.tokens.ts
@@ -1,0 +1,1 @@
+export const SETTINGS = 'DATABASE_SYNC_SETTINGS';

--- a/packages/dbsync/src/cli/commands/start/default.ts
+++ b/packages/dbsync/src/cli/commands/start/default.ts
@@ -7,89 +7,102 @@ import * as YAML from 'js-yaml';
 import { LXDHubDbSync } from '../../..';
 
 export class StartOptions extends Options {
+  @option({
+    description: 'The name of the database to connect to. Default is lxdhub',
+    type: String
+  })
+  databaseName = 'lxdhub';
 
-    @option({
-        description: 'The name of the database to connect to. Default is lxdhub',
-        type: String
-    })
-    databaseName = 'lxdhub';
+  @option({
+    description: 'The host of the database to connect to. Default is localhost',
+    type: String
+  })
+  databaseHost: string = 'postgres';
 
-    @option({
-        description: 'The host of the database to connect to. Default is localhost',
-        type: String
-    })
-    databaseHost: string = 'postgres';
+  @option({
+    description: 'The database password for the given user. Default is lxdhub',
+    type: String
+  })
+  databasePassword: string = 'lxdhub';
 
-    @option({
-        description: 'The database password for the given user. Default is lxdhub',
-        type: String
-    })
-    databasePassword: string = 'lxdhub';
+  @option({
+    description: 'The database port to connect to. Default is 5432',
+    type: Number
+  })
+  databasePort: number = 5432;
 
-    @option({
-        description: 'The database port to connect to. Default is 5432',
-        type: Number
-    })
-    databasePort: number = 5432;
+  @option({
+    description: 'The database username. Default is lxdhub',
+    type: String
+  })
+  databaseUsername: string = 'lxdhub';
 
-    @option({
-        description: 'The database username. Default is lxdhub',
-        type: String
-    })
-    databaseUsername: string = 'lxdhub';
+  @option({
+    description: 'The LXD certificate for the remote',
+    type: File,
+    required: true
+  })
+  cert: File;
 
-    @option({
-        description: 'The LXD certificate for the remote',
-        type: File,
-        required: true
-    })
-    cert: File;
+  @option({
+    description: 'The LXC key for the remote',
+    type: File,
+    required: true
+  })
+  key: File;
 
-    @option({
-        description: 'The LXC key for the remote',
-        type: File,
-        required: true
-    })
-    key: File;
+  @option({
+    description: 'The lxdhub.yml file with the configured remotes',
+    required: true,
+    type: File,
+    flag: 'c'
+  })
+  config: File;
 
-    @option({
-        description: 'The lxdhub.yml file with the configured remotes',
-        required: true,
-        type: File,
-        flag: 'c'
-    })
-    config: File;
+  @option({
+    description: 'Whether it should enforce the database synchronization run',
+    required: true,
+    type: Boolean,
+    default: false
+  })
+  force: boolean;
 }
 
 @command({
-    description: 'Start the lxdhub database synchronization'
+  description: 'Start the lxdhub database synchronization'
 })
 export default class extends Command {
-    @metadata
-    async execute(
-        options: StartOptions
-    ) {
+  @metadata
+  async execute(options: StartOptions) {
+    const database = {
+      database: options.databaseName || 'lxdhub',
+      host: options.databaseHost || 'localhost',
+      password: options.databasePassword || 'lxdhub',
+      port: options.databasePort || 5432,
+      username: options.databaseUsername || 'lxdhub'
+    };
 
-        const database = {
-            database: options.databaseName || 'lxdhub',
-            host: options.databaseHost || 'localhost',
-            password: options.databasePassword || 'lxdhub',
-            port: options.databasePort || 5432,
-            username: options.databaseUsername || 'lxdhub'
-        };
+    const lxd = {
+      cert: fs.readFile(options.cert.fullName),
+      key: fs.readFileSync(options.key.fullName)
+    };
 
-        const lxd = {
-            cert: fs.readFile(options.cert.fullName),
-            key: fs.readFileSync(options.key.fullName)
-        };
-
-        // Read the config file
-        await fs.readFile(options.config.fullName, 'utf8')
-            // Convert from YAML to JSON
-            .then(content => YAML.safeLoad(content))
-            // Create the database sync instance
-            .then((lxdhubConfig: Interfaces.ILXDHubConfig) => new LXDHubDbSync({ lxd, database, lxdhubConfig }))
-            // Run the database sync script
-            .then(dbSync => dbSync.run());
-    }
+    // Read the config file
+    await fs
+      .readFile(options.config.fullName, 'utf8')
+      // Convert from YAML to JSON
+      .then(content => YAML.safeLoad(content))
+      // Create the database sync instance
+      .then(
+        (lxdhubConfig: Interfaces.ILXDHubConfig) =>
+          new LXDHubDbSync({
+            lxd,
+            database,
+            lxdhubConfig,
+            force: options.force
+          })
+      )
+      // Run the database sync script
+      .then(dbSync => dbSync.run());
+  }
 }

--- a/packages/dbsync/src/dbsync-settings.interface.ts
+++ b/packages/dbsync/src/dbsync-settings.interface.ts
@@ -18,4 +18,8 @@ export interface LXDHubDbSyncSettings {
      * The database settings
      */
     database: IDatabaseSettings;
+    /*
+     * Whether it should ignore if other dbsyncs are running
+     */
+    force?: boolean;
 }

--- a/packages/dbsync/src/main.ts
+++ b/packages/dbsync/src/main.ts
@@ -5,36 +5,42 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { AppService } from './app.service';
 import { LXDHubDbSyncSettings } from './dbsync-settings.interface';
+import { DatabaseService } from '@lxdhub/db';
 
 /**
  * Represents the LXDHub Database synchronization script.
  * It synchronizes the database with the given remotes.
  */
 export class LXDHubDbSync implements Interfaces.ILXDHubService {
-    private app: INestApplicationContext;
-    private appService: AppService;
+  private app: INestApplicationContext;
+  private appService: AppService;
+  private databaseService: DatabaseService;
 
-    /**
-     * Initializes the database synchronization script
-     * @param settings The database synchronisation settings
-     */
-    constructor(private settings: LXDHubDbSyncSettings) { }
+  /**
+   * Initializes the database synchronization script
+   * @param settings The database synchronisation settings
+   */
+  constructor(private settings: LXDHubDbSyncSettings) {}
 
-    /**
-     * Bootstraps the NestJS application
-     * and requests the app service
-     */
-    private async bootstrap() {
-        this.app = await NestFactory.createApplicationContext(AppModule.forRoot(this.settings));
-        this.appService = this.app
-            .get(AppService);
-    }
+  /**
+   * Bootstraps the NestJS application
+   * and requests the app service
+   */
+  private async bootstrap() {
+    this.app = await NestFactory.createApplicationContext(
+      AppModule.forRoot(this.settings)
+    );
+    this.app.enableShutdownHooks();
+    this.appService = this.app.get(AppService);
+    this.databaseService = this.app.get(DatabaseService);
+  }
 
-    /**
-     * Runs the database synchronization task
-     */
-    async run() {
-        await this.bootstrap();
-        await this.appService.synchronize();
-    }
+  /**
+   * Runs the database synchronization task
+   */
+  async run() {
+    await this.bootstrap();
+    await this.appService.synchronize();
+    await this.databaseService.closeConnection();
+  }
 }

--- a/packages/dbsync/src/sync-run/index.ts
+++ b/packages/dbsync/src/sync-run/index.ts
@@ -1,0 +1,2 @@
+export * from './sync-run.module';
+export * from './sync-run.service';

--- a/packages/dbsync/src/sync-run/sync-run.module.ts
+++ b/packages/dbsync/src/sync-run/sync-run.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SyncRunService } from './sync-run.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SyncRun } from '@lxdhub/db';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SyncRun])],
+  providers: [SyncRunService],
+  exports: [SyncRunService]
+})
+export class SyncRunModule {}

--- a/packages/dbsync/src/sync-run/sync-run.service.ts
+++ b/packages/dbsync/src/sync-run/sync-run.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { SyncRun, SyncState } from '@lxdhub/db';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class SyncRunService {
+  constructor(
+    @InjectRepository(SyncRun)
+    private readonly syncRunRepository: Repository<SyncRun>
+  ) {}
+  private findOne(id: number) {
+    return this.syncRunRepository.findOne({ where: { id } });
+  }
+
+  createSyncRun(): Promise<SyncRun> {
+    const syncRun = new SyncRun();
+    return this.syncRunRepository.save(syncRun);
+  }
+
+  async startSyncRun(id: number): Promise<SyncRun> {
+    const syncRun = await this.findOne(id);
+    syncRun.state = SyncState.RUNNING;
+    syncRun.started = new Date(Date.now());
+    return syncRun.save();
+  }
+
+  async failSyncRun(id: number, message: string): Promise<SyncRun> {
+    const syncRun = await this.findOne(id);
+    syncRun.state = SyncState.FAILED;
+    syncRun.error = message;
+    syncRun.ended = new Date(Date.now());
+    return syncRun.save();
+  }
+
+  async finishSyncRun(id: number): Promise<SyncRun> {
+    const syncRun = await this.findOne(id);
+    syncRun.state = SyncState.SUCCEEDED;
+    syncRun.ended = new Date(Date.now());
+    return syncRun.save();
+  }
+
+  async resetAllSyncStates(): Promise<SyncRun[]> {
+    const currentlyRunningSyncs = await this.getCurrentlyRunningSyncs();
+    const promises = currentlyRunningSyncs.map(currentlyRunning =>
+      this.failSyncRun(currentlyRunning.id, 'Forcefully stopped')
+    );
+    return Promise.all(promises);
+  }
+
+  getCurrentlyRunningSyncs(): Promise<SyncRun[]> {
+    return this.syncRunRepository.find({ where: { state: SyncState.RUNNING } });
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6822,10 +6822,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-pretty-bytes@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.2.0.tgz#96c92c6e95a0b35059253fb33c03e260d40f5a1f"
-  integrity sha512-ujANBhiUsl9AhREUDUEY1GPOharMGm8x8juS7qOHybcLi7XsKfrYQ88hSly1l2i0klXHTDYrlL8ihMCG55Dc3w==
+pretty-bytes@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.3.0.tgz#f2849e27db79fb4d6cfe24764fc4134f165989f2"
+  integrity sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==
 
 pretty-format@^24.8.0:
   version "24.8.0"


### PR DESCRIPTION
Adds a new table `sync_run`. Logs every database synchronization run in this table. In case a database sync task is already running, the tool will prompt the user and halt the task. The user can enforce the database sync task, even if others are runnning with the `FORCE=1` flag.

This is a preparation to show when the last dbsync ran in the UI.
