### PR TITLE
fix(ansible) enforce postgressql is encrypted, mandatory for psql > 10

### DIFF
--- a/ansible/roles/postgres_setup/tasks/main.yml
+++ b/ansible/roles/postgres_setup/tasks/main.yml
@@ -20,6 +20,7 @@
   postgresql_user:
     name: lxdhub
     password: "{{ lxdhub_password }}"
+    encrypted: yes
     role_attr_flags: SUPERUSER,CREATEDB,CREATEROLE,INHERIT,LOGIN
   become: yes
   become_user: postgres


### PR DESCRIPTION
starting with psql 10
psycopg2.NotSupportedError: UNENCRYPTED PASSWORD is no longer supported
therefore enforce encrypted parameter